### PR TITLE
set model to eval mode for reproducible testing

### DIFF
--- a/test.py
+++ b/test.py
@@ -94,6 +94,8 @@ def main():
         )
         return
 
+    # evaluation
+    tester.network.eval()
     mse, rmse, mae, nse, psnr, loss, bacc = tester.vali(
         dataloader_test, torch.from_numpy(np.load("arctic_mask.npy"))
     )


### PR DESCRIPTION
Added `tester.network.eval()` to switch model to inference mode.